### PR TITLE
Enhance InUDF to support tuple version and add java compatibility for datafu-pig

### DIFF
--- a/datafu-pig/build.gradle
+++ b/datafu-pig/build.gradle
@@ -5,6 +5,9 @@ apply plugin: 'download-task'
 
 import groovy.xml.MarkupBuilder
 
+sourceCompatibility = 1.5
+targetCompatibility = 1.5
+
 buildscript {
   repositories {
       mavenCentral()

--- a/datafu-pig/src/main/java/datafu/pig/util/InUDF.java
+++ b/datafu-pig/src/main/java/datafu/pig/util/InUDF.java
@@ -52,7 +52,14 @@ public class InUDF extends FilterFunc
     Boolean match = false;
     if (o != null) {
       for (int i=1; i<input.size() && !match; i++) {
-        match = match || o.equals(input.get(i));
+        if (input.get(i) instanceof Tuple) {
+          for (int j=0; j<((Tuple)(input.get(i))).size() && !match; j++) {
+            match = match || o.equals(((Tuple)(input.get(i))).get(j));
+          }
+        } else {
+          match = match || o.equals(input.get(i));
+        }
+        
       }
     }    
     return match;


### PR DESCRIPTION
1. In many of our application, we need the IN operator for FILTER to operation on a string representing multiple values e.g. 'AU,SG,HK' for a country list. So we need IN operation to support something like 
   FILTER users BY IN(country, STRSPLIT('$country_list',',')) where the value of $country_list is 'AU,SG,HK' passed as input parameter. 

I found this one is generally useful for many application. so send the pull request 
1. Different JVM version can be used to build DataFu, but the generated jar without java compatibility support cannot run on the platform using different version of JVM. So add java compatibility suport in build.gradle.
