### PR TITLE
Keep the unmatched single records in joinWithRange

### DIFF
--- a/datafu-spark/src/main/scala/datafu/spark/SparkDFUtils.scala
+++ b/datafu-spark/src/main/scala/datafu/spark/SparkDFUtils.scala
@@ -449,7 +449,7 @@ object SparkDFUtils {
             col("decreased_single") === col("decreased_range_single"),
             "left_outer")
       .withColumn("range_size", expr("(range_end - range_start + 1)"))
-      .filter("single>=range_start and single<=range_end")
+      .filter("decreased_range_single is null or (single>=range_start and single<=range_end)")
   }
 
   /**


### PR DESCRIPTION
The filter at the end in fact causes the join to behave like 'inner' because it filters out the records from singleDf that have no matching range... because range_start and range_end are null in that case.

There may be addition places where the filtering needs to be changed, I just taken this function for my project...