### PR TITLE
Added a UDAF with the collect_limited_list functionality

### DIFF
--- a/datafu-spark/src/main/scala/datafu/spark/DataFrameOps.scala
+++ b/datafu-spark/src/main/scala/datafu/spark/DataFrameOps.scala
@@ -101,6 +101,9 @@ object DataFrameOps {
   
     def explodeArray(arrayCol: Column,
                      alias: String) =
-      SparkDFUtils.explodeArray(df, arrayCol, alias)  
+      SparkDFUtils.explodeArray(df, arrayCol, alias)
+
+    def dedupRandomN(df: DataFrame, groupCol: Column, maxSize: Int): DataFrame =
+      SparkDFUtils.dedupRandomN(df, groupCol, maxSize)
   }
 }

--- a/datafu-spark/src/main/scala/datafu/spark/SparkDFUtils.scala
+++ b/datafu-spark/src/main/scala/datafu/spark/SparkDFUtils.scala
@@ -127,6 +127,10 @@ class SparkDFUtilsBridge {
     )
   }
 
+  def dedupRandomN(df: DataFrame, groupCol: Column, maxSize: Int): DataFrame = {
+    SparkDFUtils.dedupRandomN(df, groupCol, maxSize)
+  }
+
   private def convertJavaListToSeq[T](list: JavaList[T]): Seq[T] = {
     scala.collection.JavaConverters
       .asScalaIteratorConverter(list.iterator())
@@ -541,5 +545,19 @@ object SparkDFUtils {
 
     val exprs = (0 until arrSize).map(i => arrayCol.getItem(i).alias(s"$alias$i"))
     df.select((col("*") +: exprs):_*)
+  }
+
+  /**
+    * Used get the random n records in each group. Uses an efficient implementation
+    * that doesn't order the data so it can handle large amounts of data.
+    *
+    * @param df        DataFrame to operate on
+    * @param groupCol  column to group by the records
+    * @param maxSize   The maximal number of rows per group
+    * @return DataFrame representing the data after the operation
+    */
+  def dedupRandomN(df: DataFrame, groupCol: Column, maxSize: Int): DataFrame = {
+    df.groupBy(groupCol).agg(SparkOverwriteUDAFs.collectLimitedList(expr("struct(*)"), maxSize).as("list"))
+      .select(groupCol,expr("explode(list)"))
   }
 }

--- a/datafu-spark/src/main/scala/spark/utils/overwrites/SparkOverwriteUDAFs.scala
+++ b/datafu-spark/src/main/scala/spark/utils/overwrites/SparkOverwriteUDAFs.scala
@@ -98,6 +98,7 @@ abstract class ExtramumValueByKey(
 /** *
  *
  * This code is copied from CollectList, just modified the method it extends
+ * Copied originally from https://github.com/apache/spark/blob/branch-2.3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
  *
  */
 case class CollectLimitedList(child: Expression,

--- a/datafu-spark/src/main/scala/spark/utils/overwrites/SparkOverwriteUDAFs.scala
+++ b/datafu-spark/src/main/scala/spark/utils/overwrites/SparkOverwriteUDAFs.scala
@@ -19,17 +19,23 @@
 package org.apache.spark.sql.datafu.types
 
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.DeclarativeAggregate
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Collect, DeclarativeAggregate, ImperativeAggregate}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BinaryComparison, ExpectsInputTypes, Expression, GreaterThan, If, IsNull, LessThan, Literal}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, DataType}
+
+import scala.collection.generic.Growable
+import scala.collection.mutable
 
 object SparkOverwriteUDAFs {
   def minValueByKey(key: Column, value: Column): Column =
     Column(MinValueByKey(key.expr, value.expr).toAggregateExpression(false))
   def maxValueByKey(key: Column, value: Column): Column =
     Column(MaxValueByKey(key.expr, value.expr).toAggregateExpression(false))
+  def collectLimitedList(e: Column, maxSize: Int): Column =
+    Column(CollectLimitedList(e.expr, howMuchToTake = maxSize).toAggregateExpression(false))
 }
 
 case class MinValueByKey(child1: Expression, child2: Expression)
@@ -87,4 +93,54 @@ abstract class ExtramumValueByKey(
   )
 
   override lazy val evaluateExpression: AttributeReference = data
+}
+
+/** *
+ *
+ * This code is copied from CollectList, just modified the method it extends
+ *
+ */
+case class CollectLimitedList(child: Expression,
+                              mutableAggBufferOffset: Int = 0,
+                              inputAggBufferOffset: Int = 0,
+                              howMuchToTake: Int = 10) extends LimitedCollect[mutable.ArrayBuffer[Any]](howMuchToTake) {
+
+  def this(child: Expression) = this(child, 0, 0)
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate =
+    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): ImperativeAggregate =
+    copy(inputAggBufferOffset = newInputAggBufferOffset)
+
+  override def createAggregationBuffer(): mutable.ArrayBuffer[Any] = mutable.ArrayBuffer.empty
+
+  override def prettyName: String = "collect_limited_list"
+
+}
+
+/** *
+ *
+ * This modifies the collect list / set to keep only howMuchToTake random elements
+ *
+ */
+abstract class LimitedCollect[T <: Growable[Any] with Iterable[Any]](howMuchToTake: Int) extends Collect[T] with Serializable {
+
+  override def update(buffer: T, input: InternalRow): T = {
+    if (buffer.size < howMuchToTake)
+      super.update(buffer, input)
+    else
+      buffer
+  }
+
+  override def merge(buffer: T, other: T): T = {
+    if (buffer.size == howMuchToTake)
+      buffer
+    else if (other.size == howMuchToTake)
+      other
+    else {
+      val howMuchToTakeFromOtherBuffer = howMuchToTake - buffer.size
+      buffer ++= other.take(howMuchToTakeFromOtherBuffer)
+    }
+  }
 }


### PR DESCRIPTION
Added collectLimitedList, A UDAF, which is like collect_list, but receives a parameter that limits the number of items to be collected, chosen randomly.

This is useful when one wants to collect items from a skewed dataset or to sample records per group.

Added a function `dedupRandomN` that uses collectLimitedList to select fixed random rows per key.