### PR TITLE
Added count filtering option to broadcastJoinSkewed

### DIFF
--- a/datafu-spark/src/main/resources/pyspark_utils/df_utils.py
+++ b/datafu-spark/src/main/resources/pyspark_utils/df_utils.py
@@ -99,7 +99,7 @@ def join_skewed(df_left, df_right, join_exprs, num_shards = 30, join_type="inner
     return DataFrame(jdf, df_left.sql_ctx)
 
 
-def broadcast_join_skewed(not_skewed_df, skewed_df, join_col, number_of_custs_to_broadcast):
+def broadcast_join_skewed(not_skewed_df, skewed_df, join_col, number_of_custs_to_broadcast, filter_cnt):
     """
     Suitable to perform a join in cases when one DF is skewed and the other is not skewed.
     splits both of the DFs to two parts according to the skewed keys.
@@ -109,9 +109,10 @@ def broadcast_join_skewed(not_skewed_df, skewed_df, join_col, number_of_custs_to
     :param skewed_df: skewed DataFrame
     :param join_col: join column
     :param number_of_custs_to_broadcast: number of custs to broadcast
+    :param filter_cnt: ???
     :return: DataFrame representing the data after the operation
     """
-    jdf = _get_utils(skewed_df).broadcastJoinSkewed(not_skewed_df._jdf, skewed_df._jdf, join_col, number_of_custs_to_broadcast)
+    jdf = _get_utils(skewed_df).broadcastJoinSkewed(not_skewed_df._jdf, skewed_df._jdf, join_col, number_of_custs_to_broadcast, filter_cnt)
     return DataFrame(jdf, not_skewed_df.sql_ctx)
 
 

--- a/datafu-spark/src/main/resources/pyspark_utils/df_utils.py
+++ b/datafu-spark/src/main/resources/pyspark_utils/df_utils.py
@@ -109,7 +109,7 @@ def broadcast_join_skewed(not_skewed_df, skewed_df, join_col, number_of_custs_to
     :param skewed_df: skewed DataFrame
     :param join_col: join column
     :param number_of_custs_to_broadcast: number of custs to broadcast
-    :param filter_cnt: ???
+    :param filter_cnt: filter out unskewed rows from the boardcast to ease limit calculation
     :return: DataFrame representing the data after the operation
     """
     jdf = _get_utils(skewed_df).broadcastJoinSkewed(not_skewed_df._jdf, skewed_df._jdf, join_col, number_of_custs_to_broadcast, filter_cnt)

--- a/datafu-spark/src/main/scala/datafu/spark/DataFrameOps.scala
+++ b/datafu-spark/src/main/scala/datafu/spark/DataFrameOps.scala
@@ -87,11 +87,13 @@ object DataFrameOps {
 
     def broadcastJoinSkewed(skewed: DataFrame,
                             joinCol: String,
-                            numberCustsToBroadcast: Int): DataFrame =
+                            numberCustsToBroadcast: Int,
+                            filterCnt: Option[Long] = None): DataFrame =
       SparkDFUtils.broadcastJoinSkewed(df,
                                        skewed,
                                        joinCol,
-                                       numberCustsToBroadcast)
+                                       numberCustsToBroadcast,
+                                       filterCnt)
 
     def joinSkewed(notSkewed: DataFrame,
                    joinExprs: Column,

--- a/datafu-spark/src/test/resources/python_tests/df_utils_tests.py
+++ b/datafu-spark/src/test/resources/python_tests/df_utils_tests.py
@@ -73,7 +73,7 @@ func_joinSkewed_res = df_utils.join_skewed(df_left=df_people2.alias("df1"), df_r
 func_joinSkewed_res.registerTempTable("joinSkewed")
 
 func_broadcastJoinSkewed_res = df_utils.broadcast_join_skewed(not_skewed_df=df_people2, skewed_df=simpleDF, join_col="id",
-                                                              number_of_custs_to_broadcast=5)
+                                                              number_of_custs_to_broadcast=5, filterCnt=0)
 func_broadcastJoinSkewed_res.registerTempTable("broadcastJoinSkewed")
 
 dfRange = sqlContext.createDataFrame([

--- a/datafu-spark/src/test/resources/python_tests/df_utils_tests.py
+++ b/datafu-spark/src/test/resources/python_tests/df_utils_tests.py
@@ -73,7 +73,7 @@ func_joinSkewed_res = df_utils.join_skewed(df_left=df_people2.alias("df1"), df_r
 func_joinSkewed_res.registerTempTable("joinSkewed")
 
 func_broadcastJoinSkewed_res = df_utils.broadcast_join_skewed(not_skewed_df=df_people2, skewed_df=simpleDF, join_col="id",
-                                                              number_of_custs_to_broadcast=5, filterCnt=0)
+                                                              number_of_custs_to_broadcast=5, filter_cnt=0)
 func_broadcastJoinSkewed_res.registerTempTable("broadcastJoinSkewed")
 
 dfRange = sqlContext.createDataFrame([


### PR DESCRIPTION
# Summary
Adding an option for broadcast join skew - currently, there is a parameter to take the top skewed keys.
This new option is for taking skewed keys more than a certain number.

# Details
When calculating the "limit", in cases there are many tasks, it could take a long time. 
For example, "limit 10000" mean that each task will send its 10k rows to one reducer which will then need to run a local limit on #tasks*10k. If most of these keys are not really skewed that's a waste of a lot of time.
so adding the above param to make sure only skewed keys are being shuffled.

