### PR TITLE
DATAFU-171 - Improving DedupWithCombiner to support multiple orderBy …

### DIFF
--- a/datafu-spark/src/main/resources/pyspark_utils/df_utils.py
+++ b/datafu-spark/src/main/resources/pyspark_utils/df_utils.py
@@ -67,7 +67,9 @@ def dedup_with_combiner(df, group_col, order_by_col, desc = True, columns_filter
 *                          those columns in the result
     :return: DataFrame representing the data after the operation
     """
-    jdf = _get_utils(df).dedupWithCombiner(df._jdf, group_col._jc, order_by_col._jc, desc, columns_filter, columns_filter_keep)
+    group_col = group_col if isinstance(group_col, list) else [group_col]
+    order_by_col = order_by_col if isinstance(order_by_col, list) else [order_by_col]
+    jdf = _get_utils(df).dedupWithCombiner(df._jdf, _cols_to_java_cols(group_col), _cols_to_java_cols(order_by_col), desc, columns_filter, columns_filter_keep)
     return DataFrame(jdf, df.sql_ctx)
 
 

--- a/datafu-spark/src/main/scala/datafu/spark/DataFrameOps.scala
+++ b/datafu-spark/src/main/scala/datafu/spark/DataFrameOps.scala
@@ -19,6 +19,7 @@
 package datafu.spark
 
 import org.apache.spark.sql.{Column, DataFrame}
+import scala.language.implicitConversions
 
 /**
  * implicit class to enable easier usage e.g:
@@ -32,6 +33,7 @@ import org.apache.spark.sql.{Column, DataFrame}
  */
 object DataFrameOps {
 
+  implicit def columnToColumns(c: Column): Seq[Column] = Seq(c)
   implicit class someDataFrameUtils(df: DataFrame) {
 
     def dedupWithOrder(groupCol: Column, orderCols: Column*): DataFrame =
@@ -40,8 +42,8 @@ object DataFrameOps {
     def dedupTopN(n: Int, groupCol: Column, orderCols: Column*): DataFrame =
       SparkDFUtils.dedupTopN(df, n, groupCol, orderCols: _*)
 
-    def dedupWithCombiner(groupCol: Column,
-                          orderByCol: Column,
+    def dedupWithCombiner(groupCol: Seq[Column],
+                          orderByCol: Seq[Column],
                           desc: Boolean = true,
                           moreAggFunctions: Seq[Column] = Nil,
                           columnsFilter: Seq[String] = Nil,


### PR DESCRIPTION
add improvment to DedupWithCombiner to support multiple orderBy / groupBy keys, by packing them as struct and ordering by the struct instead of single column.
User can provide single column (as in previous version) which is converted implicitly to seq(column) or directly provide Seq of columns.
Add test to cover cases not previously covered.

Change is backward compatible in both Scala and Python