### PR TITLE
DATAFU-173 Change UDAFS to use Aggregator instead of UserDefinedAggregateFunction

### DIFF
--- a/datafu-spark/src/main/scala/datafu/spark/Aggregators.scala
+++ b/datafu-spark/src/main/scala/datafu/spark/Aggregators.scala
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package datafu.spark
+
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.{Encoder, Encoders, SparkSession}
+import org.apache.spark.sql.expressions.Aggregator
+
+import scala.reflect.runtime.universe._
+import scala.collection.mutable.{Map, Set}
+import scala.reflect.ClassTag
+
+object Aggregators {
+
+  /**
+   * Like Google's MultiSets.
+   * Aggregate function that creates a map of key to its count.
+   */
+  class MultiSet extends Aggregator[String, Map[String, Int], Map[String, Int]] with Serializable {
+    
+    override def zero: Map[String, Int] = Map[String, Int]()
+
+    override def reduce(buffer: Map[String, Int], newItem: String) : Map[String, Int] = {
+      buffer.put(newItem, buffer.getOrElse(newItem, 0) + 1)
+      buffer
+    }
+
+    override def merge(buffer1: Map[String, Int], buffer2: Map[String, Int]): Map[String, Int] = {
+      for (entry <- buffer2.iterator) {
+        buffer1.put(entry._1, buffer1.getOrElse(entry._1, 0) + entry._2)
+      }
+      buffer1
+    }
+
+    val ss = SparkSession.builder.getOrCreate()
+    import ss.implicits._
+    override def finish(reduction: Map[String, Int]): Map[String, Int] = reduction
+
+    def bufferEncoder: Encoder[Map[String, Int]] = implicitly[Encoder[Map[String, Int]]]
+    def outputEncoder: Encoder[Map[String, Int]] = implicitly[Encoder[Map[String, Int]]]
+  }
+
+  // ----------------------------------------------------------------------------------------
+
+  /**
+   * Essentially the same as MultiSet, but gets an Array for input.
+   * There is an extra option to limit the number of keys (like @CountDistinctUpTo)
+   */
+
+  class MultiArraySet[IN : Ordering : TypeTag]( maxKeys: Int = -1)(implicit t:ClassTag[IN]) extends Aggregator[Array[IN], Map[IN, Int], Map[IN, Int]] with Serializable {
+
+    override def zero: Map[IN, Int] = Map[IN, Int]()
+
+    // Taken from our deprecated @SparkUDAFs.MultiArraySet implementation
+    private def limitKeys(mp: Map[IN, Int], factor: Int = 1): Map[IN, Int] = {
+      if (maxKeys > 0 && maxKeys * factor < mp.size) {
+        val k = mp.toList.map(_.swap).sorted.reverse(maxKeys - 1)._1
+        var mp2 = Map[IN, Int]() ++= mp.filter((t: (IN, Int)) =>
+          t._2 >= k)
+        var toRemove = mp2.size - maxKeys
+        if (toRemove > 0) {
+          mp2 = mp2.filter((t: (IN, Int)) => {
+            if (t._2 > k) {
+              true
+            } else {
+              if (toRemove >= 0) {
+                toRemove = toRemove - 1
+              }
+              toRemove < 0
+            }
+          })
+        }
+        mp2
+      } else {
+        mp
+      }
+    }
+    override def reduce(buffer: Map[IN, Int], newItem: Array[IN]): Map[IN, Int] = {
+      for (i <- newItem.iterator) {
+        buffer.put(i, buffer.getOrElse(i, 0) + 1)
+      }
+      limitKeys(buffer, 3)
+    }
+
+    override def merge(buffer1: Map[IN, Int], buffer2: Map[IN, Int]): Map[IN, Int] = {
+      for (i <- buffer2.iterator) {
+        buffer1.put(i._1, buffer1.getOrElse(i._1, 0) + i._2)
+      }
+      limitKeys(buffer1, 3)
+    }
+
+    override def finish(reduction: Map[IN, Int]): Map[IN, Int] = reduction
+
+    implicit val inEncoder : Encoder[IN] = Encoders.kryo[IN]
+
+    def bufferEncoder: Encoder[Map[IN, Int]] = implicitly(ExpressionEncoder[Map[IN, Int]])
+
+    def outputEncoder: Encoder[Map[IN, Int]] = implicitly(ExpressionEncoder[Map[IN, Int]])
+  }
+
+  // ----------------------------------------------------------------------------------------
+
+  /**
+   * Merge maps of kind string -> set<string>
+   */
+  class MapSetMerge extends Aggregator[Map[String, Array[String]], Map[String, Set[String]], Map[String, Array[String]]] with Serializable {
+
+      override def zero: Map[String, Set[String]] = Map[String, Set[String]]()
+
+      override def reduce(buffer: Map[String, Set[String]], newItem: Map[String, Array[String]]) : Map[String, Set[String]] = {
+        for (entry <- newItem.iterator) {
+            buffer.getOrElse(entry._1, Set[String]()) ++= entry._2
+        }
+        buffer
+      }
+
+      override def merge(buffer1: Map[String, Set[String]], buffer2: Map[String, Set[String]]): Map[String, Set[String]] = {
+        for (entry <- buffer2.iterator) {
+          if (buffer1.isDefinedAt(entry._1)) {
+            buffer1(entry._1) ++= entry._2
+          } else {
+            buffer1(entry._1) = entry._2
+          }
+        }
+        buffer1
+      }
+
+      override def finish(reduction: Map[String, Set[String]]): Map[String, Array[String]] = {
+        val result = Map[String, Array[String]]()
+
+        for (entry <- reduction.iterator) {
+          result.put(entry._1, entry._2.toArray)
+        }
+        result
+      }
+
+      val ss = SparkSession.builder.getOrCreate()
+
+      import ss.implicits._
+
+     // implicit val setEncoder : Encoder[Set[String]] = Encoders.kryo[Set[String]]
+
+    //implicit val setEncoder : Encoder[Set[String]] = implicitly[Encoder[Set[String]]]
+    //implicit val arrayEncoder : Encoder[Array[String]] = Encoders.kryo[Array[String]]
+
+      def bufferEncoder: Encoder[Map[String, Set[String]]] = implicitly[Encoder[Map[String,Set[String]]]]
+      //def bufferEncoder: Encoder[Map[String, Set[String]]] = implicitly(ExpressionEncoder[Map[String, Set[String]]])
+      def outputEncoder: Encoder[Map[String, Array[String]]] = implicitly(ExpressionEncoder[Map[String, Array[String]]])
+    }
+
+  // ----------------------------------------------------------------------------------------
+
+  /**
+   * Counts number of distinct records, but only up to a preset amount -
+   * more efficient than an unbounded count
+   */
+  class CountDistinctUpTo(maxItems: Int) extends Aggregator[String, Set[String], Int] with Serializable {
+
+    override def zero: Set[String] = Set[String]()
+
+    override def reduce(buffer: Set[String], newItem: String): Set[String] = {
+      if (buffer.size < maxItems) buffer += newItem
+      buffer
+    }
+
+    // it doesn't matter which items get put in our set if we've reached the maximum
+    override def merge(buffer1: Set[String], buffer2: Set[String]): Set[String] = {
+      if (buffer1.size >= maxItems) {
+        buffer1
+      } else if (buffer2.size >= maxItems) {
+        buffer2
+      } else {
+        val it = buffer2.iterator
+        while (buffer1.size < maxItems && it.hasNext) {
+          buffer1 += it.next
+        }
+        buffer1
+      }
+    }
+
+    override def finish(reduction: Set[String]): Int = reduction.size
+
+    val ss = SparkSession.builder.getOrCreate()
+    import ss.implicits._
+
+    def bufferEncoder: Encoder[Set[String]] = Encoders.kryo[Set[String]]
+    //def bufferEncoder: Encoder[Set[String]] = implicitly[Encoder[Set[String]]]
+
+    //def bufferEncoder: Encoder[Set[String]] = ExpressionEncoder()
+    def outputEncoder: Encoder[Int] = Encoders.scalaInt
+  }
+}

--- a/datafu-spark/src/main/scala/datafu/spark/SparkUDAFs.scala
+++ b/datafu-spark/src/main/scala/datafu/spark/SparkUDAFs.scala
@@ -25,14 +25,18 @@ import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAg
 import org.apache.spark.sql.types.{ArrayType, _}
 
 
-// @TODO: add documentation and tests to all the functions. maybe also expose in python.
-
+/**
+ * UserDefineAggregateFunction is deprecated and will be removed in DataFu 2.1.0 in order to allow compilation with Spark 3.2 and up.
+ * Please use the methods in @Aggregators instead
+ */
+@Deprecated
 object SparkUDAFs {
 
   /**
     * Like Google's MultiSets.
     * Aggregate function that creates a map of key to its count.
     */
+  @Deprecated
   class MultiSet() extends UserDefinedAggregateFunction {
 
     def inputSchema: StructType = new StructType().add("key", StringType)
@@ -84,6 +88,7 @@ object SparkUDAFs {
     * Essentially the same as MultiSet, but gets an Array for input.
     * There is an extra option to limit the number of keys (like CountDistinctUpTo)
     */
+  @Deprecated
   class MultiArraySet[T: Ordering](dt: DataType = StringType, maxKeys: Int = -1)
       extends UserDefinedAggregateFunction {
 
@@ -159,6 +164,7 @@ object SparkUDAFs {
   /**
     * Merge maps of kind string -> set<string>
     */
+  @Deprecated
   class MapSetMerge extends UserDefinedAggregateFunction {
 
     def inputSchema: StructType = new StructType().add("key", dataType)
@@ -225,6 +231,7 @@ object SparkUDAFs {
     * Counts number of distinct records, but only up to a preset amount -
     * more efficient than an unbounded count
     */
+  @Deprecated
   class CountDistinctUpTo(maxItems: Int = -1)
       extends UserDefinedAggregateFunction {
 

--- a/datafu-spark/src/test/scala/datafu/spark/TestAggregators.scala
+++ b/datafu-spark/src/test/scala/datafu/spark/TestAggregators.scala
@@ -36,7 +36,7 @@ import java.nio.file.attribute.BasicFileAttributes
 import datafu.spark.Aggregators._
 
 @RunWith(classOf[JUnitRunner])
-class AggregatorTests extends FunSuite with DataFrameSuiteBase {
+class TestAggregators extends FunSuite with DataFrameSuiteBase {
 
   import spark.implicits._
 
@@ -95,7 +95,6 @@ class AggregatorTests extends FunSuite with DataFrameSuiteBase {
   }
 
   val mas = udaf(new MultiArraySet[String]())
-  //val mas = udaf(new MultiArraySet())
 
   test("test multiarrayset simple") {
     assertDataFrameEquals(
@@ -152,7 +151,7 @@ class AggregatorTests extends FunSuite with DataFrameSuiteBase {
     spark.sql(
       "insert into table mas_table2 select array('asd2') from (select 1)z")
 
-    val mas2 = new SparkUDAFs.MultiArraySet[String](maxKeys = 2)
+    val mas2 = udaf(new Aggregators.MultiArraySet[String](maxKeys = 2))
 
     assertDataFrameEquals(
       sqlContext.createDataFrame(List(mapExp(Map("dsa" -> 1, "asd" -> 5)))),
@@ -170,7 +169,7 @@ class AggregatorTests extends FunSuite with DataFrameSuiteBase {
       .parallelize(1 to N, 20)
       .toDF("num")
       .selectExpr("array('asd',concat('dsa',num)) as arr")
-    val mas = new SparkUDAFs.MultiArraySet[String](maxKeys = 3)
+    val mas = udaf(new Aggregators.MultiArraySet[String](maxKeys = 3))
     val time1 = System.currentTimeMillis()
     val mp = blah
       .groupBy()
@@ -198,8 +197,6 @@ class AggregatorTests extends FunSuite with DataFrameSuiteBase {
       "insert into table mapmerge_table select map('k1', array('v1')) from (select 1) z")
     spark.sql(
       "insert into table mapmerge_table select map('k2', array('v3')) from (select 1) z")
-
-    spark.table("mapmerge_table").groupBy().agg(mapMerge($"c").as("map_col")).show
 
     assertDataFrameEquals(
       sqlContext.createDataFrame(
@@ -247,13 +244,6 @@ class AggregatorTests extends FunSuite with DataFrameSuiteBase {
         Exp6(Option(4), Option(1)),
         Exp6(Option(2), Option(1))
       ))
-      
- inputDF
-      .groupBy("col_ord")
-      .agg(countDistinctUpTo2($"col_grp").as("col_grp"))
-      .show
-  
-  results2DF.show
       
     assertDataFrameEquals(results3DF,
                           inputDF

--- a/datafu-spark/src/test/scala/datafu/spark/TestAggregators.scala
+++ b/datafu-spark/src/test/scala/datafu/spark/TestAggregators.scala
@@ -41,10 +41,10 @@ class TestAggregators extends FunSuite with DataFrameSuiteBase {
   import spark.implicits._
 
   /**
-    * taken from https://github.com/holdenk/spark-testing-base/issues/234#issuecomment-390150835
-    *
-    * Solves problem with Hive in Spark 2.3.0 in spark-testing-base
-    */
+   * taken from https://github.com/holdenk/spark-testing-base/issues/234#issuecomment-390150835
+   *
+   * Solves problem with Hive in Spark 2.3.0 in spark-testing-base
+   */
   override def conf: SparkConf =
     super.conf.set(CATALOG_IMPLEMENTATION.key, "hive")
 
@@ -58,34 +58,35 @@ class TestAggregators extends FunSuite with DataFrameSuiteBase {
 
   lazy val inputRDD = sc.parallelize(
     Seq(Row("a", 1, "asd1"),
-        Row("a", 2, "asd2"),
-        Row("a", 3, "asd3"),
-        Row("b", 1, "asd4")))
+      Row("a", 2, "asd2"),
+      Row("a", 3, "asd3"),
+      Row("b", 1, "asd4")))
 
   lazy val df =
     sqlContext.createDataFrame(inputRDD, StructType(inputSchema)).cache
 
   case class mapExp(map_col: Map[String, Int])
+
   case class mapArrExp(map_col: Map[String, Array[String]])
 
   lazy val defaultDbLocation = spark.sql("describe database default").toDF
-	.collect()
-	.filter(_.getString(0) == "Location")(0)(1)
-	.toString.replace("file:", "")
+    .collect()
+    .filter(_.getString(0) == "Location")(0)(1)
+    .toString.replace("file:", "")
 
-  def deleteLeftoverFiles(table : String) : Unit = {
-   
-	val tablePath = Paths.get(defaultDbLocation + File.separator + table)
-	
-	// sanity check - only delete files if the path seems to be to a Hive warehouse
-	if (defaultDbLocation.endsWith("warehouse") && Files.exists(tablePath)) Files.walkFileTree(tablePath, new SimpleFileVisitor[Path] {
-      		override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        		Files.delete(path)
-        		FileVisitResult.CONTINUE
-      		}
-    	}
-  )
- }
+  def deleteLeftoverFiles(table: String): Unit = {
+
+    val tablePath = Paths.get(defaultDbLocation + File.separator + table)
+
+    // sanity check - only delete files if the path seems to be to a Hive warehouse
+    if (defaultDbLocation.endsWith("warehouse") && Files.exists(tablePath)) Files.walkFileTree(tablePath, new SimpleFileVisitor[Path] {
+      override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.delete(path)
+        FileVisitResult.CONTINUE
+      }
+    }
+    )
+  }
 
   test("test multiset simple") {
     val ms = udaf(new MultiSet())
@@ -110,19 +111,19 @@ class TestAggregators extends FunSuite with DataFrameSuiteBase {
     // end case
     spark.sql("drop table if exists mas_table")
     deleteLeftoverFiles("mas_table")
-    	
+
     spark.sql("create table mas_table (arr array<string>)")
     spark.sql(
       "insert overwrite table mas_table select case when 1=2 then array('asd') end " +
-        "from (select 1)z")
+        "from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
 
     val expected = sqlContext.createDataFrame(List(mapExp(Map())))
 
@@ -139,17 +140,17 @@ class TestAggregators extends FunSuite with DataFrameSuiteBase {
 
     spark.sql("create table mas_table2 (arr array<string>)")
     spark.sql(
-      "insert overwrite table mas_table2 select array('asd','dsa') from (select 1)z")
+      "insert overwrite table mas_table2 select array('asd','dsa') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd','abc') from (select 1)z")
+      "insert into table mas_table2 select array('asd','abc') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd') from (select 1)z")
+      "insert into table mas_table2 select array('asd') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd') from (select 1)z")
+      "insert into table mas_table2 select array('asd') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd') from (select 1)z")
+      "insert into table mas_table2 select array('asd') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd2') from (select 1)z")
+      "insert into table mas_table2 select array('asd2') from (select 1)")
 
     val mas2 = udaf(new Aggregators.MultiArraySet[String](maxKeys = 2))
 
@@ -185,7 +186,7 @@ class TestAggregators extends FunSuite with DataFrameSuiteBase {
   }
 
   test("test mapmerge") {
-    val mapMerge = udaf( new MapSetMerge())
+    val mapMerge = udaf(new MapSetMerge())
 
     spark.sql("drop table if exists mapmerge_table")
     deleteLeftoverFiles("mapmerge_table")
@@ -206,6 +207,7 @@ class TestAggregators extends FunSuite with DataFrameSuiteBase {
   }
 
   case class Exp5(col_grp: String, col_ord: Option[Int])
+
   case class Exp6(col_ord: Option[Int], col_grp: Option[Int])
 
   test("countDistinctUpTo") {
@@ -237,27 +239,27 @@ class TestAggregators extends FunSuite with DataFrameSuiteBase {
         Exp5("a", Option(4))
       ))
 
- val results2DF = sqlContext.createDataFrame(
+    val results2DF = sqlContext.createDataFrame(
       List(
-      	Exp6(Option(1), Option(2)),
-      	Exp6(Option(3), Option(1)),
+        Exp6(Option(1), Option(2)),
+        Exp6(Option(3), Option(1)),
         Exp6(Option(4), Option(1)),
         Exp6(Option(2), Option(1))
       ))
-      
+
     assertDataFrameEquals(results3DF,
-                          inputDF
-                            .groupBy("col_grp")
-                            .agg(countDistinctUpTo3($"col_ord").as("col_ord")))
+      inputDF
+        .groupBy("col_grp")
+        .agg(countDistinctUpTo3($"col_ord").as("col_ord")))
 
     assertDataFrameEquals(results6DF,
-                          inputDF
-                            .groupBy("col_grp")
-                            .agg(countDistinctUpTo6($"col_ord").as("col_ord")))
-                            
-       assertDataFrameEquals(results2DF,inputDF
-                            .groupBy("col_ord")
-                            .agg(countDistinctUpTo2($"col_grp").as("col_grp")))
+      inputDF
+        .groupBy("col_grp")
+        .agg(countDistinctUpTo6($"col_ord").as("col_ord")))
+
+    assertDataFrameEquals(results2DF, inputDF
+      .groupBy("col_ord")
+      .agg(countDistinctUpTo2($"col_grp").as("col_grp")))
   }
 
 

--- a/datafu-spark/src/test/scala/datafu/spark/TestSparkUDAFs.scala
+++ b/datafu-spark/src/test/scala/datafu/spark/TestSparkUDAFs.scala
@@ -114,15 +114,15 @@ class UdafTests extends FunSuite with DataFrameSuiteBase {
     spark.sql("create table mas_table (arr array<string>)")
     spark.sql(
       "insert overwrite table mas_table select case when 1=2 then array('asd') end " +
-        "from (select 1)z")
+        "from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
     spark.sql(
-      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)z")
+      "insert into table mas_table select case when 1=2 then array('asd') end from (select 1)")
 
     val expected = sqlContext.createDataFrame(List(mapExp(Map())))
 
@@ -139,17 +139,17 @@ class UdafTests extends FunSuite with DataFrameSuiteBase {
 
     spark.sql("create table mas_table2 (arr array<string>)")
     spark.sql(
-      "insert overwrite table mas_table2 select array('asd','dsa') from (select 1)z")
+      "insert overwrite table mas_table2 select array('asd','dsa') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd','abc') from (select 1)z")
+      "insert into table mas_table2 select array('asd','abc') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd') from (select 1)z")
+      "insert into table mas_table2 select array('asd') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd') from (select 1)z")
+      "insert into table mas_table2 select array('asd') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd') from (select 1)z")
+      "insert into table mas_table2 select array('asd') from (select 1)")
     spark.sql(
-      "insert into table mas_table2 select array('asd2') from (select 1)z")
+      "insert into table mas_table2 select array('asd2') from (select 1)")
 
     val mas2 = new SparkUDAFs.MultiArraySet[String](maxKeys = 2)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ group=org.apache.datafu
 version=2.0.0-SNAPSHOT
 gradleVersion=5.6.4
 sparkCompatVersion=3.0
-sparkVersion=3.0.0
+sparkVersion=3.1.1
 hadoopVersion=2.7.0
 release=false


### PR DESCRIPTION
This pull request
1) creates a new class, Aggregators, which contains new implementations of all the classes in SparkUDAFs that extended the deprecated UserDefinedAggregateFunction class.
2) a copy of the tests for SparkUDAFs for the new versions
3) deprecates the classes in SparkUDAFs

See https://issues.apache.org/jira/browse/DATAFU-173 for more details