### PR TITLE
[DATAFU-185]fix(build): resolve rat license-check paths against project root

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 github:
   rulesets:
     - name: "Default Branch Protection"

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -28,18 +28,19 @@ class RatTask extends DefaultTask {
   @Input
   List<String> excludes
 
-  def reportPath = 'build/rat'
-  def stylesheet = 'gradle/resources/rat-output-to-html.xsl'
+  def reportPath = "${project.buildDir}/rat"
+  def stylesheet = "${project.projectDir}/gradle/resources/rat-output-to-html.xsl"
   def xmlReport = reportPath + '/rat-report.xml'
   def htmlReport = reportPath + '/rat-report.html'
 
   def generateXmlReport(File reportDir) {
     def antBuilder = services.get(IsolatedAntBuilder)
     def ratClasspath = project.configurations.rat
+    def scanDir = project.projectDir
     antBuilder.withClasspath(ratClasspath).execute {
       ant.taskdef(resource: 'org/apache/rat/anttasks/antlib.xml')
       ant.report(format: 'xml', reportFile: xmlReport) {
-        fileset(dir: ".") {
+        fileset(dir: scanDir) {
           patternset {
             excludes.each {
               exclude(name: it)


### PR DESCRIPTION
The `:rat` task used relative paths, which the Gradle daemon's embedded Ant builder resolves against the daemon working directory (`~/.gradle/daemon/5.6.4/`) instead of the project root - so it scanned the wrong directory and could not find the report stylesheet, failing `./gradlew clean assemble`.

Switched to absolute paths (`project.projectDir` / `project.buildDir`). Verified `assemble` now passes with `:rat` succeeding.

Also added the missing Apache license header to `.asf.yaml`, which `:rat` flagged as an unknown license.

JIRA: https://issues.apache.org/jira/browse/DATAFU-185